### PR TITLE
Reintroduce ProtectedRoute

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Login from './components/Login';
 import Register from './components/Register';
 import Secret from './components/Secret';
 import { UserProvider } from './utils/UserContext';
+import ProtectedRoute from './utils/ProtectedRoute';
 
 const Root = styled.div`
   background-color: #282c34;
@@ -34,7 +35,7 @@ const App = () => (
             <Route exact path="/" component={Home} />
             <Route path="/login" component={Login} />
             <Route path="/register" component={Register} />
-            <Route path="/secret" component={Secret} />
+            <ProtectedRoute path="/secret" component={Secret} />
           </Switch>
         </Container>
         <Footer />

--- a/src/utils/ProtectedRoute.js
+++ b/src/utils/ProtectedRoute.js
@@ -1,0 +1,23 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import useToken from './useToken';
+
+const ProtectedRoute = ({ component: Component, ...rest }) => {
+  const token = useToken('status');
+  return (
+    <Route
+      {...rest}
+      render={props =>
+        token.status === 'logged-in' ? <Component {...props} /> : <Redirect to="/login" />
+      }
+    />
+  );
+};
+
+ProtectedRoute.propTypes = {
+  component: PropTypes.func.isRequired,
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
After reintroducing ProtectedRoute, I am able to redirect logged-out users to the /login page if they try to access /secret.